### PR TITLE
Always endorse that there is target directory for theme

### DIFF
--- a/install-papirus-root.sh
+++ b/install-papirus-root.sh
@@ -36,6 +36,7 @@ sudo rm -rf "/usr/share/smplayer/themes/Papirus" \
   "/usr/share/smplayer/themes/ePapirus" \
   "/usr/share/smplayer/themes/PapirusDark"
 echo "=> Installing ..."
+sudo mkdir -p /usr/share/smplayer/themes
 sudo cp --no-preserve=mode,ownership -r \
   "$temp_dir/$gh_repo-master/Papirus" \
   "$temp_dir/$gh_repo-master/ePapirus" \


### PR DESCRIPTION
Always check target directory existence for themes and create it in
case it doesn't exists (as it really is in some systems like Arch Linux).